### PR TITLE
Adding a wire protocol

### DIFF
--- a/api_socket.go
+++ b/api_socket.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"log"
+	"net"
+	"strings"
+)
+
+func HandleCommand(conn net.Conn, body string) {
+	var response string
+	parts := strings.SplitN(body, " ", 3)
+
+	if len(parts) >= 2 {
+		command := strings.ToLower(parts[0])
+		key := parts[1]
+
+		switch command {
+		case "set":
+			if len(parts) > 2 {
+				arg := parts[2]
+				DB.Data[key] = arg
+				response = "1"
+			} else {
+				response = "!ERR: missing argument for 'set'"
+			}
+		case "get":
+			data := DB.Data[key]
+			response = data
+		case "delete":
+			delete(DB.Data, key)
+			response = "1"
+		default:
+			log.Println("Invalid command: ", command)
+			response = "!ERR: invalid command"
+		}
+
+		_, err := conn.Write([]byte(response + "\n"))
+		if err != nil {
+			log.Printf("ERROR (w): ")
+			log.Println(err)
+		}
+	}
+}
+
+func HandleConnection(connection net.Conn) {
+	reader := bufio.NewReader(connection)
+
+	for {
+		body, err := reader.ReadBytes('\n')
+		if err != nil {
+			log.Println(err)
+			connection.Close()
+			return
+		}
+
+		cleanBody := strings.TrimSpace(string(body))
+		HandleCommand(connection, cleanBody)
+	}
+}
+
+func SocketStart(listenAddress string) {
+	server, err := net.Listen("tcp", listenAddress)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		for {
+			conn, err := server.Accept()
+			if err != nil {
+				log.Println(err)
+			}
+			go HandleConnection(conn)
+		}
+	}()
+
+	log.Println("Socket listening on", listenAddress)
+}

--- a/api_web.go
+++ b/api_web.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func DBMethod(w http.ResponseWriter, req *http.Request) {
+	key := strings.TrimPrefix(req.RequestURI, "/db/")
+
+	if key == "" {
+		WebNotFoundError(w)
+		return
+	}
+
+	switch req.Method {
+	case "GET":
+		if value, ok := DB.Data[key]; ok {
+			io.WriteString(w, value)
+		} else {
+			WebNotFoundError(w)
+		}
+	case "POST", "PUT", "PATCH":
+		body, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			WebServerError(w, err)
+			log.Println(err)
+			return
+		}
+		DB.Data[key] = string(body)
+
+		w.WriteHeader(200)
+	case "DELETE":
+		delete(DB.Data, key)
+		w.WriteHeader(200)
+	}
+}
+
+func WebNotFoundError(w http.ResponseWriter) {
+	w.WriteHeader(404)
+	io.WriteString(w, "Not found")
+}
+
+func WebServerError(w http.ResponseWriter, err error) {
+	w.WriteHeader(500)
+	io.WriteString(w, err.Error())
+}
+
+func WebStart(listenAddress string) {
+	http.HandleFunc("/db/", DBMethod)
+
+	log.Printf("Web listening on %s\n", listenAddress)
+	log.Fatal(http.ListenAndServe(listenAddress, nil))
+}


### PR DESCRIPTION
HTTP API is great for simplicity and testing, but you lose add a *lot* of overhead in requests. On each request, you're adding a bunch of HTTP headers that aren't necessary to the DB's functionality.

A wire protocol is therefore necessary if you want your database benchmarks to be competitive at all. It highly decreases the number of bytes per request and the amount of latency for each request, since you can have a long lived connection.